### PR TITLE
refactor: update database connection configuration

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,8 +10,7 @@ generator client {
 
 datasource db {
   provider  = "postgresql"
-  url       = env("POSTGRES_PRISMA_URL") // uses connection pooling
-  directUrl = env("POSTGRES_URL_NON_POOLING") // uses a direct connection
+  url       = env("DATABASE_URL")
 }
 
 model Admin {


### PR DESCRIPTION
Replace the PostgreSQL connection URLs in the Prisma schema. 
Use a single environment variable, DATABASE_URL, for improved 
clarity and consistency in database connection management.