### PR TITLE
refactor(database): change controlNumber to TEXT type

### DIFF
--- a/prisma/migrations/20241208034347_change_transaction_ids/migration.sql
+++ b/prisma/migrations/20241208034347_change_transaction_ids/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "SuccessStory" ALTER COLUMN "controlNumber" SET DATA TYPE TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -163,7 +163,7 @@ model SuccessStory {
   barangayId         String?
   Barangay           Barangay? @relation(fields: [barangayId], references: [id], onDelete: Cascade)
   nameOfCalamity     String?   @db.VarChar(191)
-  controlNumber      String?   @db.VarChar(191)
+  controlNumber      String?   @db.Text
   transactionIds     String?   @db.Text
   batchNumber        String?   @db.VarChar(191)
   numberOfRecipients Int?


### PR DESCRIPTION
Updates the controlNumber field in the SuccessStory model to use 
TEXT data type instead of VarChar(191) for better handling of 
longer control numbers. This change ensures that the database can 
store larger values without truncation. Additionally, the migration 
file is created to reflect this alteration in the database schema.